### PR TITLE
Use Mono 6.x with Gnome 3.36

### DIFF
--- a/Pinta.yaml
+++ b/Pinta.yaml
@@ -5,6 +5,7 @@ sources:
     sha256: 7fbabd701c45bd23654606308fce5dc2839cd8b4a2a4b6747fc46d1b5bede269
   # Update the project and solution files for mono4
   # https://github.com/gentoo/gentoo/blob/4492fc08041affcc2dd8a43096db275958016100/media-gfx/pinta/files/pinta-1.6-mono-4.patch
+  # Solved in https://github.com/PintaProject/Pinta/commit/2e33aadeb28a6f480c5c50647a8a4fa726016780
   - type: patch
     path: pinta-1.6-mono-4.patch
   # Update XDG files

--- a/com.github.PintaProject.Pinta.yaml
+++ b/com.github.PintaProject.Pinta.yaml
@@ -8,7 +8,7 @@ rename-desktop-file: pinta.desktop
 rename-icon: pinta
 copy-icon: true
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.mono5
+  - org.freedesktop.Sdk.Extension.mono6
 finish-args:
   # X11 + XShm access
   - --share=ipc
@@ -36,10 +36,10 @@ finish-args:
   # OpenGL access
   - --device=dri
 build-options:
-  append-path: /usr/lib/sdk/mono5/bin
-  append-ld-library-path: /usr/lib/sdk/mono5/lib
+  append-path: /usr/lib/sdk/mono6/bin
+  append-ld-library-path: /usr/lib/sdk/mono6/lib
   env:
-    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/mono5/lib/pkgconfig
+    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/mono6/lib/pkgconfig
 modules:
   - Pinta.yaml
 cleanup:

--- a/com.github.PintaProject.Pinta.yaml
+++ b/com.github.PintaProject.Pinta.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.PintaProject.Pinta
 runtime: org.gnome.Platform
-runtime-version: '3.32'
+runtime-version: '3.36'
 sdk: org.gnome.Sdk
 command: pinta
 rename-appdata-file: pinta.appdata.xml

--- a/gtk-sharp.yaml
+++ b/gtk-sharp.yaml
@@ -5,6 +5,9 @@ sources:
     sha256: 02680578e4535441064aac21d33315daa009d742cab8098ac8b2749d86fffb6a
   - type: patch
     path: gtk-sharp2-2.12.12-glib-include.patch
+  # https://github.com/mono/gtk-sharp/commit/3faabd7bdce8f3e3e59f0ee945f4f36ea6d3e870
+  - type: patch
+    path: gtk-sharp2-2.12.45-range-disambiguation.patch
   - type: shell
     commands:
       - cp -p /usr/share/automake-*/config.{sub,guess} .;

--- a/gtk-sharp2-2.12.45-range-disambiguation.patch
+++ b/gtk-sharp2-2.12.45-range-disambiguation.patch
@@ -1,0 +1,13 @@
+diff --git a/sample/test/TestRange.cs b/sample/test/TestRange.cs
+index 35fc8a6dd..d44a77d85 100644
+--- a/sample/test/TestRange.cs
++++ b/sample/test/TestRange.cs
+@@ -9,6 +9,8 @@
+ using System;
+ 
+ using Gtk;
++// disambiguate, Gtk.Range vs System.Range
++using Range=Gtk.Range;
+ 
+ namespace WidgetViewer {
+ 

--- a/mono-runtime.yaml
+++ b/mono-runtime.yaml
@@ -4,4 +4,4 @@ build-options:
   no-debuginfo: true
   strip: true
 build-commands:
-  - /usr/lib/sdk/mono5/install.sh;
+  - /usr/lib/sdk/mono6/install.sh;

--- a/pinta-1.6-xdg.patch
+++ b/pinta-1.6-xdg.patch
@@ -1,7 +1,7 @@
 From 900797d8baa7b29038222540db7b4d91a53fa15a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Matthias=20Mail=C3=A4nder?= <matthias@mailaender.name>
 Date: Sun, 21 Aug 2016 12:03:00 +0200
-Subject: [PATCH 1/4] Add a Linux AppData file.
+Subject: [PATCH 1/5] Add a Linux AppData file.
 
 ---
  po/POTFILES.in           |  1 +
@@ -79,7 +79,7 @@ index 00000000..3894bdb4
 From 48911d3f7634243c7e0a48dd3f6d0167d0b04c0b Mon Sep 17 00:00:00 2001
 From: scx <scx.mail@gmail.com>
 Date: Fri, 7 Dec 2018 23:35:53 +0100
-Subject: [PATCH 2/4] Enhance AppData file
+Subject: [PATCH 2/5] Enhance AppData file
 
 ---
  xdg/pinta.appdata.xml.in | 47 +++++++++++++++++++++++++++++++++++-----
@@ -154,7 +154,7 @@ index 3894bdb4..2bb76beb 100644
 From d03208ef71e3433c4bb8a891840afb96864ad93a Mon Sep 17 00:00:00 2001
 From: scx <scx.mail@gmail.com>
 Date: Sun, 27 Oct 2019 13:04:52 +0100
-Subject: [PATCH 3/4] Update XDG files
+Subject: [PATCH 3/5] Update XDG files
 
 Desktop file:
  - Add Version entry
@@ -225,7 +225,7 @@ index 5a9e4fe7..d4e00003 100644
 From ceaa184e6e976e53d1414c40c69f9e716118c414 Mon Sep 17 00:00:00 2001
 From: scx <scx.mail@gmail.com>
 Date: Sun, 27 Oct 2019 14:44:58 +0100
-Subject: [PATCH 4/4] Install AppData file
+Subject: [PATCH 4/5] Install AppData file
 
 ---
  Pinta.Install.proj | 2 ++
@@ -251,3 +251,35 @@ index b5b98576..bca73b4e 100644
      <Delete Files="$(DataRootDir)/applications/pinta.desktop" />
      <Delete Files="$(DataRootDir)/pixmaps/pinta.xpm" />
      <Delete Files="$(DataRootDir)/icons/hicolor/16x16/apps/pinta.png" />
+
+From 7b26cc90bb96a1b978120dfa8e1d86db2f25b17b Mon Sep 17 00:00:00 2001
+From: Dark Dragon <darkdragon-001@web.de>
+Date: Tue, 11 Aug 2020 09:21:43 +0200
+Subject: [PATCH] Fix URLs in appdata.
+
+---
+ xdg/pinta.appdata.xml.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/xdg/pinta.appdata.xml.in b/xdg/pinta.appdata.xml.in
+index e6d9dc0b..0fc0d87b 100644
+--- a/xdg/pinta.appdata.xml.in
++++ b/xdg/pinta.appdata.xml.in
+@@ -23,14 +23,14 @@
+   <screenshots>
+     <screenshot type="default">
+       <caption>Main window</caption>
+-      <image>https://pinta-project.com/pintaproject/pinta/theme/images/ss1.jpg</image>
++      <image>https://www.pinta-project.com/theme/images/ss1.jpg</image>
+     </screenshot>
+   </screenshots>
+   <developer_name>Jonathan Pobst</developer_name>
+   <url type="bugtracker">https://bugs.launchpad.net/pinta</url>
+   <url type="faq">https://communiroo.com/pintaproject/pinta/questions</url>
+-  <url type="help">https://pinta-project.com/pintaproject/pinta/howto</url>
+-  <url type="homepage">https://pinta-project.com</url>
++  <url type="help">https://www.pinta-project.com/howto</url>
++  <url type="homepage">https://www.pinta-project.com</url>
+   <url type="translate">https://translations.launchpad.net/pinta</url>
+   <content_rating type="oars-1.0" />
+   <translation type="gettext">pinta</translation>


### PR DESCRIPTION
Mono 6.x is strongly recommended for [Mac](https://www.mono-project.com/download/stable/#download-mac) and [Linux](https://bugs.launchpad.net/pinta/+bug/1877235) users.

Closes #8 (Gnome 3.36).