### PR TITLE
Remove org.gtk.vfs name that never existed

### DIFF
--- a/com.github.PintaProject.Pinta.yaml
+++ b/com.github.PintaProject.Pinta.yaml
@@ -28,7 +28,6 @@ finish-args:
   # GVfs access
   - --filesystem=xdg-run/gvfs
   - --filesystem=xdg-run/gvfsd
-  - --talk-name=org.gtk.vfs
   - --talk-name=org.gtk.vfs.*
   # OpenGL access
   - --device=dri


### PR DESCRIPTION
See https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access