### PR TITLE
Update for Pinta 2.1

### DIFF
--- a/Pinta.yaml
+++ b/Pinta.yaml
@@ -3,8 +3,8 @@ sources:
   - nuget_sources.json
   - type: git
     url: https://github.com/PintaProject/Pinta.git
-    tag: "2.0.2"
-    commit: 7ca0ee17d2a4b8e4f087f11508f1f448b445a690
+    tag: "2.1"
+    commit: 65667d140d8d150eca153e09684380850a8326c6
     x-checker-data:
       type: git
       tag-pattern: ^([\d.]+)$
@@ -15,21 +15,13 @@ sources:
       # Generate list via: https://github.com/flatpak/flatpak-builder-tools/tree/master/dotnet/flatpak-dotnet-generator.py nuget_sources.json Pinta.sln
       - sed -i "s|^PINTA_BUILD_OPTS.*|& --source $(pwd)/nuget-sources|" Makefile.am
 build-options:
-  append-path: /usr/lib/sdk/dotnet6/bin
-  append-ld-library-path: /usr/lib/sdk/dotnet6/lib
+  append-path: /usr/lib/sdk/dotnet7/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet7/lib
   env:
-    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet6/lib/pkgconfig
+    PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet7/lib/pkgconfig
     DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
 post-install:
-  - |
-    icon_in="xdg/scalable/pinta.svg";
-    icon_out="pinta.png";
-    for s in {16,22,24,32,36,48,64,72,96,128,192,256,512}; do
-      [[ ! -f "${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/${icon_out}" ]] || continue;
-      rsvg-convert "${icon_in}" -w "${s}" -h "${s}" -a -f png -o "${icon_out}";
-      install -p -D -m 0644 "${icon_out}" -t "${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/";
-    done;
   - gtk-update-icon-cache --force --ignore-theme-index "${FLATPAK_DEST}/share/icons/hicolor";
   - |
     for f in "${FLATPAK_DEST}/share/metainfo/pinta.appdata.xml"; do

--- a/com.github.PintaProject.Pinta.yaml
+++ b/com.github.PintaProject.Pinta.yaml
@@ -1,6 +1,6 @@
 app-id: com.github.PintaProject.Pinta
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '43'
 sdk: org.gnome.Sdk
 command: pinta
 rename-appdata-file: pinta.appdata.xml
@@ -8,7 +8,7 @@ rename-desktop-file: pinta.desktop
 rename-icon: pinta
 copy-icon: true
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet6
+  - org.freedesktop.Sdk.Extension.dotnet7
 finish-args:
   # X11 + XShm access
   - --share=ipc

--- a/dotnet-runtime.yaml
+++ b/dotnet-runtime.yaml
@@ -4,5 +4,5 @@ build-options:
   no-debuginfo: true
   strip: true
 build-commands:
-  - /usr/lib/sdk/dotnet6/bin/install.sh
+  - /usr/lib/sdk/dotnet7/bin/install.sh
 

--- a/nuget_sources.json
+++ b/nuget_sources.json
@@ -1,143 +1,206 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/pangosharp/3.24.24.34/pangosharp.3.24.24.34.nupkg",
-        "sha512": "88409cfe319bfbd8ea8d950d77a23f0ca2125e442635403554b7424bf9c029e4ef127a71d51cc6ac5554266c144b36bddcc0c6e32a5efe3cad6afbca6b878ac4",
+        "url": "https://api.nuget.org/v3-flatcontainer/atksharp/3.24.24.38/atksharp.3.24.24.38.nupkg",
+        "sha512": "46efbcd406d58a958b81e30b1ac466f08023e72eb36305cdcb17ed3e5a5e1844d44be8852add83ecff887e70dd7fc84f2e47f3aa6996728c40144788a7203adf",
         "dest": "nuget-sources",
-        "dest-filename": "pangosharp.3.24.24.34.nupkg"
+        "dest-filename": "atksharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/sharpziplib/1.3.3/sharpziplib.1.3.3.nupkg",
-        "sha512": "5f6996e38a31861449a493b9387e91097abe06f3ca936e618e6b914091699b7319bda7e392a532a96c06287e9b3c28786183c5fbc212ac2bbdd10809151e6dbb",
+        "url": "https://api.nuget.org/v3-flatcontainer/benchmarkdotnet/0.13.2/benchmarkdotnet.0.13.2.nupkg",
+        "sha512": "00966d3dfe84fe1692b30023b679e102965f9cd94e3207c3da5fd6c264486cc3b068a7530570611eff1e301075713af3512f158dacf16a4d39b8215aa5e5ec64",
         "dest": "nuget-sources",
-        "dest-filename": "sharpziplib.1.3.3.nupkg"
+        "dest-filename": "benchmarkdotnet.0.13.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/paragonclipper/6.4.2/paragonclipper.6.4.2.nupkg",
-        "sha512": "c9f311b519bc419c82f8446fc8138f1b4cea9600acb1c3be07705032312b1c16cd87813d09950e6330650764f7f1b3da1356a306c071ff9bac7189edf6e9819d",
+        "url": "https://api.nuget.org/v3-flatcontainer/benchmarkdotnet.annotations/0.13.2/benchmarkdotnet.annotations.0.13.2.nupkg",
+        "sha512": "a63eadca2c1fc9e0ed46581541875b84be224b7db3dfa27540c1b8b1a9416b595d984da67ee2e39811cdbb70a546fa1f7e5392467f5e9172acd0d6b2d61d7acb",
         "dest": "nuget-sources",
-        "dest-filename": "paragonclipper.6.4.2.nupkg"
+        "dest-filename": "benchmarkdotnet.annotations.0.13.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/giosharp/3.24.24.34/giosharp.3.24.24.34.nupkg",
-        "sha512": "d819521adcfc7d2db01eb6509739405f8d861d1dcc563a6db35faab7a49096c1a7cb70bba00aee8beb69f618a959d53576910f6378d3c160f32f4079e9cb13e9",
+        "url": "https://api.nuget.org/v3-flatcontainer/cairosharp/3.24.24.38/cairosharp.3.24.24.38.nupkg",
+        "sha512": "30294df0e349b0ba0b0191494e6f6de9bcda0471c95ea82b031a5cc0f966678c99527b16a5daf3da085aa2fa12f86ccb7633b8abb4b77dab62611c22a2e966f8",
         "dest": "nuget-sources",
-        "dest-filename": "giosharp.3.24.24.34.nupkg"
+        "dest-filename": "cairosharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/gdksharp/3.24.24.34/gdksharp.3.24.24.34.nupkg",
-        "sha512": "282b559f85853467a4c66a857ecdbc21ed827d33461d7a70ab7762551ff961e31a477779c20e9c5f03e63b3f5c6b0267996ad475693b4cc44aed124f51cdb495",
+        "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.4.3/commandlineparser.2.4.3.nupkg",
+        "sha512": "dff5a9482b07368e1a4d268d5bd4a7992a91343811e2678a5499f96a72999ff851fe51a70e9f076c332ed7fc361973978b6ac0851114d5c37040cb44b654759a",
         "dest": "nuget-sources",
-        "dest-filename": "gdksharp.3.24.24.34.nupkg"
+        "dest-filename": "commandlineparser.2.4.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/ngettext/0.6.7/ngettext.0.6.7.nupkg",
-        "sha512": "0b4d1012332965a4ef64fb91d8c7deea7a8e5cdacc3f023baee671669e15bd2dcdaedce569c916730416fd6b709fc49ad0cf69438165c2fe2a2b7dda1420ae93",
+        "url": "https://api.nuget.org/v3-flatcontainer/gdksharp/3.24.24.38/gdksharp.3.24.24.38.nupkg",
+        "sha512": "f8acc3ae6a3212a9ddc60d17cbc6bee9220624b3a25848acbaf716a3fe72390c15a0af09ca34040beabad361fcdd84901919b5ba2fbc8da8c00488fd616530bb",
         "dest": "nuget-sources",
-        "dest-filename": "ngettext.0.6.7.nupkg"
+        "dest-filename": "gdksharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/glibsharp/3.24.24.34/glibsharp.3.24.24.34.nupkg",
-        "sha512": "d7901747cdbc4f4840a1c1bfc3c3a86babd8a4b87486a8b1e0f12f41a6ce4c09c49b91494e8840107b2df0143da5511bba162937fae82db8ce5049b985fa37e4",
+        "url": "https://api.nuget.org/v3-flatcontainer/giosharp/3.24.24.38/giosharp.3.24.24.38.nupkg",
+        "sha512": "3a71150688e94393adc40b48975a17f3ac737a0984773aad218b940a8f934e7006996ecf813ffec82cc66705e753dd88cb905f587ab3fc7dc06ab03a76fd25f6",
         "dest": "nuget-sources",
-        "dest-filename": "glibsharp.3.24.24.34.nupkg"
+        "dest-filename": "giosharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/cairosharp/3.24.24.34/cairosharp.3.24.24.34.nupkg",
-        "sha512": "8589828a0f64cb377844bb2e7b329c4372c6f4de336c55d27cb74f0373f967df707756f3742a7f02ec145f71262c9114f35f5ebb853c3c57aff972931b2a013b",
+        "url": "https://api.nuget.org/v3-flatcontainer/glibsharp/3.24.24.38/glibsharp.3.24.24.38.nupkg",
+        "sha512": "b7eb31edae955673892e12408420a62641d95f65b8b8efb9e04b9aa9c0ed36d07453ed9491abfbf90e10f6a8718e2e1e4e8f358f1fe2a4dfd162010aabb7a496",
         "dest": "nuget-sources",
-        "dest-filename": "cairosharp.3.24.24.34.nupkg"
+        "dest-filename": "glibsharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/gtksharp/3.24.24.34/gtksharp.3.24.24.34.nupkg",
-        "sha512": "05ebce61e63e0020dcc812baea9018c7bdb4970d5cf328b96cbeebd034ac2b0c68ede7e582ccdaca8fcf86554340ba1b44e5a012c87a14b4142f6b5d8f8e8ea6",
+        "url": "https://api.nuget.org/v3-flatcontainer/gtksharp/3.24.24.38/gtksharp.3.24.24.38.nupkg",
+        "sha512": "51915872aaa11c200aebb62e0969471b5a8a9c5a57f449b9b7ead0dc0c4291caf271570ab5262c78da416304f5ba75cab48823ab1ee8a3752233edb843c1bac0",
         "dest": "nuget-sources",
-        "dest-filename": "gtksharp.3.24.24.34.nupkg"
+        "dest-filename": "gtksharp.3.24.24.38.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/atksharp/3.24.24.34/atksharp.3.24.24.34.nupkg",
-        "sha512": "9985de9ed5dfcc376c3880f156f9807d427161509332c1af0fb92897adef17e2e9d21b52b4fd09da5bba9055807356a11e76a5a3659130eb3878c781db493a74",
+        "url": "https://api.nuget.org/v3-flatcontainer/iced/1.17.0/iced.1.17.0.nupkg",
+        "sha512": "6404bf5518b3d7a7c74478edd56c2c2f194ccadd1cfde3ae7c13c332e442779b817b99744aae19dd4c6400a205055eee7dfc16b43a2f97d0f5200a9bc6c97549",
         "dest": "nuget-sources",
-        "dest-filename": "atksharp.3.24.24.34.nupkg"
+        "dest-filename": "iced.1.17.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.handles/4.0.1/system.runtime.handles.4.0.1.nupkg",
-        "sha512": "966a943195b66118277a340075609676e951216d404478ac55196760f0b7b2bd9314bfbb38051204a1517c53097bd656e588e8ab1ec336ce264957956695848a",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/1.1.0/microsoft.bcl.asyncinterfaces.1.1.0.nupkg",
+        "sha512": "4277ce265233e5ebf15370e7d42cf8574c1fce715a892eadbeba136136dbc36ba4d78b4090e55217293f8421f2eb84bcfdc9343de42a2d5e06b8ff5b00d0723d",
         "dest": "nuget-sources",
-        "dest-filename": "system.runtime.handles.4.0.1.nupkg"
+        "dest-filename": "microsoft.bcl.asyncinterfaces.1.1.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.0.1/system.diagnostics.tools.4.0.1.nupkg",
-        "sha512": "a812ccbbdd0a66eb57075121ea6332a526803ef883ca9f8b06431d6668ad50efd13624fa87dfaf6aed03c652f795c2ffb9fa9d9895a2fafa96eca614cbf86cdb",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.bcl.asyncinterfaces/6.0.0/microsoft.bcl.asyncinterfaces.6.0.0.nupkg",
+        "sha512": "221a05a0c910f7a87b620d8f3831ed392b4eb95d112bee274d35f27009ad2a26445de9d7cd235fe6fb4a03f2550874bda3be3dddd96edaf9c0852a9c23d7b099",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tools.4.0.1.nupkg"
+        "dest-filename": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.0.0/system.threading.tasks.extensions.4.0.0.nupkg",
-        "sha512": "f294f1a4179f53d59f91f01a372cc7896bf8c322e9827299cb1aa3ae2b1f809e98034834f5ccd4cb3fa1c30735082d244fff6584dab6e8870ad409b55e8a4986",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/2.6.2-beta2/microsoft.codeanalysis.analyzers.2.6.2-beta2.nupkg",
+        "sha512": "39658317c649c1d188719bdf4faa6a69cead0fbb29361c4b5f803e84f7d7b4a55b2c8e57d3f9ba50da1863d01723440d4c8ee5ca0e46b0bee30a04933012ae1a",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.extensions.4.0.0.nupkg"
+        "dest-filename": "microsoft.codeanalysis.analyzers.2.6.2-beta2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.4.0.1.nupkg",
-        "sha512": "dce1c4074938391ea4ea01226812982a893bfc910e66ac99ecfe31c9b6fe635f3fbff11dcab222ed5036eb21c4f49cd3f121c310adbf87d22cf3d512bf6a9d73",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.0.0/microsoft.codeanalysis.common.3.0.0.nupkg",
+        "sha512": "9f084b67db5ac76313ef815b2dd44a6df3a0d2cf5092de1b32de512650a26be5a9d5b2de4a9590e83a3ecbc8be65296434750c1c0275d7a73e06e107a730a2a2",
         "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.primitives.4.0.1.nupkg"
+        "dest-filename": "microsoft.codeanalysis.common.3.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.0.1/system.io.filesystem.4.0.1.nupkg",
-        "sha512": "a6478b17f5d52fc5b9517458e93e1a69b92575c170f44046b3f4e25c7e67c9d4126ab486f5a3c51abcb279d05a057bd53aa8f49a1e51eae69563ae39214b72d3",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/3.0.0/microsoft.codeanalysis.csharp.3.0.0.nupkg",
+        "sha512": "34ba360353ac7d0d00a32556bca0aa7ed691c0e717afbdd044880a1095cc48ddfad0df074d042aed28b334e217129ec118dace3b5987e38c06d51acb7bb707ca",
         "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.4.0.1.nupkg"
+        "dest-filename": "microsoft.codeanalysis.csharp.3.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.0.1/system.reflection.emit.lightweight.4.0.1.nupkg",
-        "sha512": "542863fa085a31705b0b294b64744c11617a098beae4d5664beb53189148d19246c9a112de30f2d597e0888069a414f2aed8e94a2b369294a81b24b991bc2149",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codecoverage/17.4.1/microsoft.codecoverage.17.4.1.nupkg",
+        "sha512": "60dd9648ef5e642a5dd0d8f5701f9103525ea5a9aa4abd6d0fbbe570d29237d3c946b6783050dbc4fbf5eaa5e239fdf7833c786b4ffb8f2837bc1a0dd6f047b8",
         "dest": "nuget-sources",
-        "dest-filename": "system.reflection.emit.lightweight.4.0.1.nupkg"
+        "dest-filename": "microsoft.codecoverage.17.4.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.ilgeneration/4.0.1/system.reflection.emit.ilgeneration.4.0.1.nupkg",
-        "sha512": "c3819cd3a58f609ff579652536f9f414481caa4d9e7dc277e0d3c8c8fe8e0ff90806fa94f7c6436d4af853c6fccd26d5af57f0a49c5baceef4e0daaa39e26773",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.diagnostics.netcore.client/0.2.251802/microsoft.diagnostics.netcore.client.0.2.251802.nupkg",
+        "sha512": "553336be495e4d899318256fdf085e7800e6cd01a50ba561a3fb879d12f75bd42d58383bdb7b0e679d6f9ba7414b9b5b9d07ded6150a57651e16d1e95cd804a4",
         "dest": "nuget-sources",
-        "dest-filename": "system.reflection.emit.ilgeneration.4.0.1.nupkg"
+        "dest-filename": "microsoft.diagnostics.netcore.client.0.2.251802.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.0.1/system.reflection.emit.4.0.1.nupkg",
-        "sha512": "ff7766886b945148ea65a49e4ddc648336340def2c2e94b8277b584444ec9126d96918f0bcbeb62016a530623a89ccd9eae749d62065b01058387b5d09fc7dd1",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.diagnostics.runtime/2.2.332302/microsoft.diagnostics.runtime.2.2.332302.nupkg",
+        "sha512": "7b682033f65f6ae06f8c63d6d607551861e1f36045cd670f8b39e28786958c5e7da10426f9ce13762a9a88edb8aa2e730c0a7d04455a61e3e014327ab06dde18",
         "dest": "nuget-sources",
-        "dest-filename": "system.reflection.emit.4.0.1.nupkg"
+        "dest-filename": "microsoft.diagnostics.runtime.2.2.332302.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg",
-        "sha512": "6ed8e75f945a18651066fe9ee31cf6c8257a5974340fe4d262438903c4959a479f4a515a4d1389e6d3d3ab34f09a3c7bc2009aada2e8a7f697b6655a82d3bfc9",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.diagnostics.tracing.traceevent/3.0.2/microsoft.diagnostics.tracing.traceevent.3.0.2.nupkg",
+        "sha512": "31fe5d47f445629e350a27b981f2eb97a9a9842746f8beaec553eb5832b8cb8362ada825d73cdafc02736a92836a16a1f21fe6b375f918241d553a9ae47d8ce0",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.targets.1.0.1.nupkg"
+        "dest-filename": "microsoft.diagnostics.tracing.traceevent.3.0.2.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/1.0.1/microsoft.netcore.platforms.1.0.1.nupkg",
-        "sha512": "5f3622dafd8fe8f3406c7a7ee506a7363c9955b28819ae1f2b067c38eae7ab6e620eb63442929b967c94fc511e47a2b7547ab62b6f1aafe37daa222499c9bb19",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.dotnet.platformabstractions/3.1.6/microsoft.dotnet.platformabstractions.3.1.6.nupkg",
+        "sha512": "55b87f544874686bed96889953b7e99e43426b79b0fac31cc452e0f4a27ca5cc08522c0ac967bf9df649f7c04137a5e2553d134ad79d5c1e69578367c2b4b4c6",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.1.0.1.nupkg"
+        "dest-filename": "microsoft.dotnet.platformabstractions.3.1.6.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration/2.1.1/microsoft.extensions.configuration.2.1.1.nupkg",
+        "sha512": "ede33ede2f538757a8ad6c607e374080d510010e5e1c716cc11980b32fda72c5f9b6e9a505cdb4ea082256c95662854604972a33e5b82e5e63f30b67fd3f04c5",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.abstractions/2.1.1/microsoft.extensions.configuration.abstractions.2.1.1.nupkg",
+        "sha512": "ee6acc03f6f030f0f1df7f515a83aa43f18b50355d7951324566a0eb22cec06aec67a1291d268b8a0f9d2201f5b455b33abaad516393e6dd11e9939dd801ff82",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.abstractions.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.configuration.binder/2.1.1/microsoft.extensions.configuration.binder.2.1.1.nupkg",
+        "sha512": "faf0c073239b014de6c3b2edf61b7ca72b655ca96a678a405c6e511162485e446d75fe63b82b807a900470245b1f3e68f4b7ac4be8ae14d89f4f21e615dc6b55",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.configuration.binder.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.dependencyinjection.abstractions/2.1.1/microsoft.extensions.dependencyinjection.abstractions.2.1.1.nupkg",
+        "sha512": "026d9465857a9ee07121a85abb15f525014e8cdab89f3f4efb80dd4ddad07cf643af2cba82bebd1100c5c61a4dac459ad6f534abc560799737ad909ca140e5af",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.dependencyinjection.abstractions.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging/2.1.1/microsoft.extensions.logging.2.1.1.nupkg",
+        "sha512": "1c1988872213742dad197f4309436334cdb517721cef1b3b3f72b689520d1f846b10398ded82389f45d9669ce6ced4ef0c72dfff93e109ace75c7bbd4e569b05",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.logging.abstractions/2.1.1/microsoft.extensions.logging.abstractions.2.1.1.nupkg",
+        "sha512": "7eb031114a70af9f9fe82d84935cadedeb3bd9a9c60e00c914d741cf0d52b9f854cb82abbf294b2494e46603b14deca2c4b5e2cb39591df990e7f79b3a327091",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.logging.abstractions.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.options/2.1.1/microsoft.extensions.options.2.1.1.nupkg",
+        "sha512": "55c72f83c97892406b5c00da965b84198373f475d23188a52a849a2dd69600deb48029b2488072cf987857cd8627afb353065c3a8c81ae38a7af4baf4f897ee5",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.options.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.extensions.primitives/2.1.1/microsoft.extensions.primitives.2.1.1.nupkg",
+        "sha512": "4c24e6b4cdedd5e7928bebd95c82ea4fdbcd068a0e7ae07d54284445f78ff973e2ec108957af1e0f51090c2fcba579006fedd92b615df27a3b53790797aa3391",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.extensions.primitives.2.1.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.test.sdk/17.4.1/microsoft.net.test.sdk.17.4.1.nupkg",
+        "sha512": "5901d8c30db965f97cfe6b363690811a3559e17687e928df8087e15ab96d6ac4499f961af31029db7ef73d4c0672ae80c468b875f8b5e40fff038e78b429316c",
+        "dest": "nuget-sources",
+        "dest-filename": "microsoft.net.test.sdk.17.4.1.nupkg"
     },
     {
         "type": "file",
@@ -148,66 +211,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices/4.1.0/system.runtime.interopservices.4.1.0.nupkg",
-        "sha512": "e8511e6a4cd40f3c603df4ffbbf6a4aac4d10be79bcfd0249a9af90d55cf2a02543ad9b82e607a4665d58f28c7ce9bdb0f7f3ff9bc8ded8a252213916a771bd2",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg",
+        "sha512": "0827f83639833a88ac7bb1408a3d953ee1c880a2acbbaf7abe44f084e90f5507cbb13981d962c57d0e3278ee5476d93c143eb7e9404cc7a63d7a8bf324a4fbe8",
         "dest": "nuget-sources",
-        "dest-filename": "system.runtime.interopservices.4.1.0.nupkg"
+        "dest-filename": "microsoft.netcore.platforms.2.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.typeextensions/4.1.0/system.reflection.typeextensions.4.1.0.nupkg",
-        "sha512": "5b1875ae86f76f60307fbe261c7471e996d4d4eade0c4783cb35a5aad7fec4f01be01cb1f1f78af22d483ecce12096f6ed431d69c4a66c7bf235008bcac30cb7",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.objectmodel/17.4.1/microsoft.testplatform.objectmodel.17.4.1.nupkg",
+        "sha512": "feaf5d1d9a1b111e377d43f916c46e8338b4918f4d513feb05bb1807c44fde12265b4ebfaec57666c7e5fe0f15a35758212d126a9dd0ec7503b54eded375aa4a",
         "dest": "nuget-sources",
-        "dest-filename": "system.reflection.typeextensions.4.1.0.nupkg"
+        "dest-filename": "microsoft.testplatform.objectmodel.17.4.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.primitives/4.0.1/system.reflection.primitives.4.0.1.nupkg",
-        "sha512": "08ad6f78c5f68af95a47b0854b4ee4360c4bad6e83946c2e45eaa88b48d27d06618c6b7479bd813eb5f30a2db486590d17645e9c0e06a72dbe12ffd37730707e",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.testhost/17.4.1/microsoft.testplatform.testhost.17.4.1.nupkg",
+        "sha512": "889ed3a857baed9b4e8d3bf29656a55638f7b8291f80e6a0d7a76f75b9331551328e55a6258236fe18102ed5e3ee56f7f5a2f8ec4b2914c07e56c5d5dc86a122",
         "dest": "nuget-sources",
-        "dest-filename": "system.reflection.primitives.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.0.11/system.xml.xdocument.4.0.11.nupkg",
-        "sha512": "f8ae902901963f2636f39c0652d82daa9df3fb3e3d5a60493c39f6cf01ed07c7d57f175a2d2895f4a872d4e92527e5131522218d1a67da2fd491e162273a8527",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.xdocument.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.0.11/system.xml.readerwriter.4.0.11.nupkg",
-        "sha512": "d40d6e9d55e57acdf04132bcb8ae8abf1abb3483620cde969c78c6c393a9936abf742c1dcf66288e6e9dffcb399a880ee3c11540ac140cb32e20b41365aaf35e",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.readerwriter.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks/4.0.11/system.threading.tasks.4.0.11.nupkg",
-        "sha512": "fb66c496a5b4c88c5cb6e9d7b7d220e10f2fc0aed181420390f12f8d9986a1bd2829e9f1bf080bb6361cd8b8b4ffc9b622288dfa42124859e1be1e981b5cfa7b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nunit/3.13.2/nunit.3.13.2.nupkg",
-        "sha512": "7e82869c5d9c92aeae440c9b9f0d4f20c0ec0f1769d6b6ee101278b762d86b91c32fcd2639c1148dd6d5a910cc4ec28d8a291f90f101a1ec86578d995e22cb40",
-        "dest": "nuget-sources",
-        "dest-filename": "nunit.3.13.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.test.sdk/17.0.0/microsoft.net.test.sdk.17.0.0.nupkg",
-        "sha512": "8fd66711d69708363c7dbe20cc4c845b94c6370cdc09c9b5c721361856a474064ea09efa16f3d8fa66bd63f572522c4456ecb2908b2885c69425862c0fdee830",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.test.sdk.17.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nunit3testadapter/4.1.0/nunit3testadapter.4.1.0.nupkg",
-        "sha512": "0e38c25a3a3fa5d1fdc54a2a82c00f08e8500a24eb5a4516739d8392c902de813b5c09dd0e5f2796cbf5285b361041b8d2592a8593e6c6171e79e61ca99524af",
-        "dest": "nuget-sources",
-        "dest-filename": "nunit3testadapter.4.1.0.nupkg"
+        "dest-filename": "microsoft.testplatform.testhost.17.4.1.nupkg"
     },
     {
         "type": "file",
@@ -218,31 +239,122 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.testhost/17.0.0/microsoft.testplatform.testhost.17.0.0.nupkg",
-        "sha512": "1847ff4c93809e214d4f66892525d3564699e38872fd80fe857a6b61e2bdf19cb7c2f2519f9405e11471080adb8311a2c7f8f49ce0e71277f3c120af15cb42a4",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+        "sha512": "83731b662eaf05379a23f8446ef47bbc111349dd4358b7bd8b51383fe9cf637e2fe62f78cea52a0d7bdd582dc6fbbb5837d4a7b1d53dcf37a0ae7473e21ee7b1",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.testplatform.testhost.17.0.0.nupkg"
+        "dest-filename": "newtonsoft.json.13.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codecoverage/17.0.0/microsoft.codecoverage.17.0.0.nupkg",
-        "sha512": "af91eb6f3919a61b4277471f421041bdeabe88e071b67a6ee06e0d1f2f60d012137346389ac0b60956f6e61515a068c4a1ab91bd947ac08bd4a3d62d90dd2292",
+        "url": "https://api.nuget.org/v3-flatcontainer/ngettext/0.6.7/ngettext.0.6.7.nupkg",
+        "sha512": "0b4d1012332965a4ef64fb91d8c7deea7a8e5cdacc3f023baee671669e15bd2dcdaedce569c916730416fd6b709fc49ad0cf69438165c2fe2a2b7dda1420ae93",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.codecoverage.17.0.0.nupkg"
+        "dest-filename": "ngettext.0.6.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.testplatform.objectmodel/17.0.0/microsoft.testplatform.objectmodel.17.0.0.nupkg",
-        "sha512": "19ad56cad83f5897c5b93608be9d357c83ddd5f97f2f7751f40fc017236ae2ef3b0517147e4dba2c4395511a9f4f5b262a4f660a25974e7b34f220c275af9c4e",
+        "url": "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.11.0/nuget.frameworks.5.11.0.nupkg",
+        "sha512": "1b3b1ad7813654c84d6c0b48d81a60c2eb060307693d993323cd563fac5462b1deba931a1a59e07b67e8208ca42d62a1ffd66349d5d34fabb2790484ed854944",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.testplatform.objectmodel.17.0.0.nupkg"
+        "dest-filename": "nuget.frameworks.5.11.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/9.0.1/newtonsoft.json.9.0.1.nupkg",
-        "sha512": "da8917a5347051c8106f4ea9bade4bc300a3b60a05a3be3390f92c8dcbcea67223c7b4da8065b9228042000e25b99c75fad7e2221a0daa8888ed8ef3c161b228",
+        "url": "https://api.nuget.org/v3-flatcontainer/nunit/3.13.3/nunit.3.13.3.nupkg",
+        "sha512": "09dfca502d636c3123adf93331732db354e9e280935d1bbd7923d710f5b29adf82d41efc763e2ce8781dde01d81bbb21af168d897d5820a53c15a0f9bcf11f20",
         "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.9.0.1.nupkg"
+        "dest-filename": "nunit.3.13.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/nunit3testadapter/4.3.1/nunit3testadapter.4.3.1.nupkg",
+        "sha512": "c1360618758a129b8c5fefb143958aea3e50b5a4378f976c7416b483a3795eee29d0e1fb1d5c4f922e2f9f94362e51c60fb66abd826d3c84f9d55660bc59f46f",
+        "dest": "nuget-sources",
+        "dest-filename": "nunit3testadapter.4.3.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/pangosharp/3.24.24.38/pangosharp.3.24.24.38.nupkg",
+        "sha512": "5edc84db5b815d3fe8162b39f6c6f1f44107e216dfaf63e2c5677ca4f7d2a552558a51e6dba9910820358bbc70fe6aef58321e691271095cac2c98dad29a7f3a",
+        "dest": "nuget-sources",
+        "dest-filename": "pangosharp.3.24.24.38.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/paragonclipper/6.4.2/paragonclipper.6.4.2.nupkg",
+        "sha512": "c9f311b519bc419c82f8446fc8138f1b4cea9600acb1c3be07705032312b1c16cd87813d09950e6330650764f7f1b3da1356a306c071ff9bac7189edf6e9819d",
+        "dest": "nuget-sources",
+        "dest-filename": "paragonclipper.6.4.2.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/perfolizer/0.2.1/perfolizer.0.2.1.nupkg",
+        "sha512": "9db50cdcf13a85737c275a0aa3dc4a98b97e7d23e7aca1c9b27df28e454b0d4587315bd62f7181dc03e0257a83d79c7af2e90733eafda70afe5a956c92c20a9a",
+        "dest": "nuget-sources",
+        "dest-filename": "perfolizer.0.2.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharpziplib/1.4.1/sharpziplib.1.4.1.nupkg",
+        "sha512": "3f051f41f91577291da0d317d210547752251aae07f5060c1f8ff71917477f44ade9674f9862d6ce76d3c2a7a57b700165ee573286054d6dee1ea825f383f59e",
+        "dest": "nuget-sources",
+        "dest-filename": "sharpziplib.1.4.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.codedom/6.0.0/system.codedom.6.0.0.nupkg",
+        "sha512": "2b911b7c9bc524c86562a26547dfc92a8c774ed5937993a4a22e8a9ca1b146151aeaeaf15e4271ff6fe6cf20af634815aa1485a5a4c48d24acf39b2a6bc3cf27",
+        "dest": "nuget-sources",
+        "dest-filename": "system.codedom.6.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg",
+        "sha512": "4f95c64257078443bbe50c77f061825033dd9389ffef2ad1993832e32733cc957c6a53c76b13d4e794c10b6505ae4438d9bbb7e2c64f7cad1d53e9d665438424",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.immutable.1.5.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/5.0.0/system.collections.immutable.5.0.0.nupkg",
+        "sha512": "726f8db7d179714cf0efeb0fc02fcebe7b4755762902e391e77cf78671dd5d5f364c7cf4ce3545b51cc7f37327d12d1500ba19f4b934f0e8bb69a6a347c0bbfd",
+        "dest": "nuget-sources",
+        "dest-filename": "system.collections.immutable.5.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.management/6.0.0/system.management.6.0.0.nupkg",
+        "sha512": "d98847c56d026a1cb6bac6b2dfb34aa9976b86754217eb80063cda76c391dee54a0f1accf19e1a76dedb7e1c63f815bcbb6c81380a76f8bd4c58680773601a43",
+        "dest": "nuget-sources",
+        "dest-filename": "system.management.6.0.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.1/system.memory.4.5.1.nupkg",
+        "sha512": "a289e72d03d90060f6d6ab4d306e04b5599b60e2279368d5eccfa0d74f01e8e1ce6faed939a5a703f2bc3f9a10eae2bdc312b30758845d20a140e8b6b1c28ea8",
+        "dest": "nuget-sources",
+        "dest-filename": "system.memory.4.5.1.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.3/system.memory.4.5.3.nupkg",
+        "sha512": "70fce15a52cc76aacbae05c8e89e2e398d1d32903f63f640a7dd4a3e5747f2c7a887d4bfd22f2a2e40274906cf91648dfd169734fb7c74eb9b4f72614084e1db",
+        "dest": "nuget-sources",
+        "dest-filename": "system.memory.4.5.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.7.0/system.reflection.emit.4.7.0.nupkg",
+        "sha512": "10c0325b993a31d993c58adeee5f1c6fd7ff66173bf22bf0d295d29bfb30f0e01ec3042aceac5e245bb62d8fbfed63ce02adf74e04cf55811e0cf3d541b897a9",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.4.7.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit.lightweight/4.7.0/system.reflection.emit.lightweight.4.7.0.nupkg",
+        "sha512": "065af503d56a93e654927964eac16b84e729baac786e9ee4ab065f8709269a1cfef5d80e97c719f429d25db6a56cbf6b7c79a2e470c5c9dc50b1fa339763ef8d",
+        "dest": "nuget-sources",
+        "dest-filename": "system.reflection.emit.lightweight.4.7.0.nupkg"
     },
     {
         "type": "file",
@@ -253,142 +365,51 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nuget.frameworks/5.0.0/nuget.frameworks.5.0.0.nupkg",
-        "sha512": "ebb9444b3b46063522e3b432c67acafe8943da39c866978146f88757f1be5571bf40e9df208824440efa4116b0b47d00f9708a72767a22878a78aca5a9887650",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.0/system.runtime.compilerservices.unsafe.4.5.0.nupkg",
+        "sha512": "91433424f3077ddb5e7869bfafdfed765b1d74f5753d4900cdc814b5c53b2d79f96582a85d4cab3e9f4e6ab042cb72514b99e4ec1b7077e5cc304aa14b3aee34",
         "dest": "nuget-sources",
-        "dest-filename": "nuget.frameworks.5.0.0.nupkg"
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading/4.0.11/system.threading.4.0.11.nupkg",
-        "sha512": "05c0dd1bbcfcedb6fc6c5f311c41920a4775f8a28a61ca246b6c65ad8afd9b04881d3357880af000ac056fd121fc5c3ec0b56d6fd607e0c27e7a639157c85e3e",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.3/system.runtime.compilerservices.unsafe.4.5.3.nupkg",
+        "sha512": "765d87d36a7b7415dee5b6cbd3a08ead9762915fbfacfad8a205a78d4a187cec6677da2407f7f7c2d1b55fe9f8c0257925c9b0bc193d402972c323979678baab",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.4.0.11.nupkg"
+        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.csharp/4.0.1/microsoft.csharp.4.0.1.nupkg",
-        "sha512": "c0e75a9162f28ba4c4572c8fac4fd4c8c97d6d3505a37683646ba5f7e5f6ac0da69d5200d2646054de90e8e08f893a10e514591b69b8273640842b2cf90bddec",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/5.0.0/system.runtime.compilerservices.unsafe.5.0.0.nupkg",
+        "sha512": "23226c503b06abecee5a9604a6e4dd3dabcdf921f55d6aa6dad2bab1ca12a001c7866af5a6de01cc9b4ace54e5c8ee1d5c2fd29dd9dfd7eda3ed86f9b35fa59f",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.csharp.4.0.1.nupkg"
+        "dest-filename": "system.runtime.compilerservices.unsafe.5.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections/4.0.11/system.collections.4.0.11.nupkg",
-        "sha512": "f61b75329ba5d7c0e688aa9d110b2200c8934c3a1888f6b1b5f198baa7ab93f23835e8380853e8c046f257172b5060578ed86df26e5fe0ef34d8c4408a02c33f",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg",
+        "sha512": "f30a16d34c8792db60b2240363a8b200cab28bc2c7441405cf19abf71dbf5fb0bf3bd1cbec4d9b5eb4cf73ec482e4505d08d80afdef00b2b4b3bb56d6d4cae96",
         "dest": "nuget-sources",
-        "dest-filename": "system.collections.4.0.11.nupkg"
+        "dest-filename": "system.security.principal.windows.4.7.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.debug/4.0.11/system.diagnostics.debug.4.0.11.nupkg",
-        "sha512": "02f4d0bf969eb1a876def21c1ffd75f8ed5f979aed9a1169f409e60a6e07016854e2154da5c0164fabaeaf6527a18d8e67282db1b69327a1b3581e9c0c742f58",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/4.5.0/system.text.encoding.codepages.4.5.0.nupkg",
+        "sha512": "6909e55204fe24affcd62bfadb313b851ec56493a029b30dbb194ae65eaedc2721b59d851b92c832779d9af5604f5a614e75f8a96094228c9f193425c6b2cda2",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.debug.4.0.11.nupkg"
+        "dest-filename": "system.text.encoding.codepages.4.5.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.dynamic.runtime/4.0.11/system.dynamic.runtime.4.0.11.nupkg",
-        "sha512": "0b2189a6f50effab44a8b1f883f2a1f9b9b32c448123190e8946a877c28ff46a235aa90af0898d1ccd6da2f3155aa2cf26e57f7f61ee7e3c50dfde2190d781ab",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg",
+        "sha512": "68052086e77d3c7198737a3da163d67740b7c44f93250c39659b3bf21b6547a9abf64cbf40481f5c78f24361af3aaf47d52d188b371554a0928a7f7665c1fc14",
         "dest": "nuget-sources",
-        "dest-filename": "system.dynamic.runtime.4.0.11.nupkg"
+        "dest-filename": "system.threading.tasks.extensions.4.5.4.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization/4.0.11/system.globalization.4.0.11.nupkg",
-        "sha512": "66bc21667f5f839bc711eda3b0463863d70e0ad86770fd5410e0123006d6f031755cf7220187fb7cefed69b3f4a9eab8f0868cae765cb1425c8bf60427f395e6",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.11.0/tmds.dbus.0.11.0.nupkg",
+        "sha512": "efa0e5d4e803964da25c23fcd678a6078da9c0ac6a1351a46b507a1209230b97aa90678e1cdae51a122f3d2b8106e0ef34d23d45fc9a680fe21f6e9740665e80",
         "dest": "nuget-sources",
-        "dest-filename": "system.globalization.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.1.0/system.io.4.1.0.nupkg",
-        "sha512": "e01b432f3d715f3c88d5d7f3e7cc1ceee78caf99407a11c3306f9103aee78963f818417f14eec52f0096fa247900a31e53bd3226e06f0c0f93870db0b2b78331",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq/4.1.0/system.linq.4.1.0.nupkg",
-        "sha512": "53e53220e5fdd6ad44f498e4657503780bca1f73be646009134150f06a76b0873753db3aae97398054bd1e8cc0c1c4cdd2db773f65a26874ab94110edb0cddb1",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.linq.expressions/4.1.0/system.linq.expressions.4.1.0.nupkg",
-        "sha512": "04605a091d3aea404bc97cb7ffc154708b3bec886562d9e36aecd4d2ed130afbb45f54cd16a3f714f0ccb3f27c5bc7707e55fbc3e81681a783e9396930058acc",
-        "dest": "nuget-sources",
-        "dest-filename": "system.linq.expressions.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.objectmodel/4.0.12/system.objectmodel.4.0.12.nupkg",
-        "sha512": "f5191cdb360bd2624abd7454c66862540f97aa19df92ea0854786b9d3cb9549e95c6194cfe8adc01589203c4feb1673a129c4929486bcb5f8db83ea535477c53",
-        "dest": "nuget-sources",
-        "dest-filename": "system.objectmodel.4.0.12.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.1.0/system.text.regularexpressions.4.1.0.nupkg",
-        "sha512": "9b612027e43c33cc256e016e0b400547c5923e93ab6ed1a40d2b97292cb18a1195fa79aba2b0166a6b11842a0fef6685d31b848375daffdf6d2acf297af40bbe",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.regularexpressions.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection/4.1.0/system.reflection.4.1.0.nupkg",
-        "sha512": "67143ef8f6fb1044830c70c66e9a2b4f1850f50df5dadfaa5177338362ea7b9e9fe4b0ba59cd4eac6e1c8db4e0c285c239e4c2b3ce61391618b411aaff45f7c2",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.extensions/4.0.1/system.reflection.extensions.4.0.1.nupkg",
-        "sha512": "3e2f07c29836735be6247e75f760de90783d5ece64e8cce4e23eceb777da8975a35130804d87ddd26449c13d2ca34180e3f6b844b0fdd2dc594bbec6e7272098",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.extensions.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.resources.resourcemanager/4.0.1/system.resources.resourcemanager.4.0.1.nupkg",
-        "sha512": "5165916e258dd38fa83278fb98dce271a95e0091c1274b8cf5f17d88b9e6284f7a7bf145194afe4f20250cc31ad714141f9e0687cf235ff05460fb47cea0c525",
-        "dest": "nuget-sources",
-        "dest-filename": "system.resources.resourcemanager.4.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg",
-        "sha512": "4b05eb68bb485846707c4fe3393f9616d3ffb6c5f62a121d81142ddf7d0241c931fe96d193b7bf02281a9368458e0764466766557cfa9709035dc76d8fdd7706",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.extensions/4.1.0/system.runtime.extensions.4.1.0.nupkg",
-        "sha512": "42d009be57d6497aa0724924891289f3decd916d0432c1c865cc0494092f5e59287f632a70c5060b3c78e361ab04510d75dfb3c2d2853f54201f735eb6e2dea6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.extensions.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.1.1/system.runtime.serialization.primitives.4.1.1.nupkg",
-        "sha512": "fa6a90aeb26c0f1e72c48abec0b60a1ebea955cd3c1133b3245c04dd0bd6984c0ce0253944d28676abb8edb93e1c649c693e7c6425459a3c29a74381531cb540",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.serialization.primitives.4.1.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding/4.0.11/system.text.encoding.4.0.11.nupkg",
-        "sha512": "f974335143f36b318abf040ed535887f28089d749b1fa55056345df5243dfbd56d27b74c6e4d87a737fdbb8e699c5291bd25f1e5db4700bb00bf53330c7e3e9a",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.4.0.11.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.0.11/system.text.encoding.extensions.4.0.11.nupkg",
-        "sha512": "b2ba1f2a96bf14466fb31e4ac1fad25e7032688357340ad8976b8aafe7cbe39c061835a4e17d7cf6ae291d3155f07d3371f6b65ffc1c15474c3c86dbb7735e82",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.extensions.4.0.11.nupkg"
+        "dest-filename": "tmds.dbus.0.11.0.nupkg"
     }
 ]


### PR DESCRIPTION
- Upgrade to .NET 7
- Update to the latest nuget package versions
- Remove some icon generation and copying. This broke with upstream
commit 921292f2f1b44e9f53f159460695c164487d7e34, but shouldn't be
necessary anymore since Pinta installs the application icons to the
correct location now.